### PR TITLE
Add ec2 tags in resource detection processor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	go.opentelemetry.io/collector/cmd/issuegenerator v0.0.0-20201201185019-f4f68db25d1f
 	go.opentelemetry.io/collector/cmd/mdatagen v0.0.0-20201201185019-f4f68db25d1f
 	golang.org/x/sys v0.0.0-20201113233024-12cec1faf1ba
-	honnef.co/go/tools v0.0.1-2020.1.6
+	honnef.co/go/tools v0.1.0
 )
 
 // Replace references to modules that are in this repository with their relateive paths

--- a/go.sum
+++ b/go.sum
@@ -2037,7 +2037,6 @@ honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.5/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.6 h1:W18jzjh8mfPez+AwGLxmOImucz/IFjpNlrKVnaj2YVc=
 honnef.co/go/tools v0.0.1-2020.1.6/go.mod h1:pyyisuGw24ruLjrr1ddx39WE0y9OooInRzEYLhQB2YY=
-honnef.co/go/tools v0.1.0 h1:AWNL1W1i7f0wNZ8VwOKNJ0sliKvOF/adn0EHenfUh+c=
 honnef.co/go/tools v0.1.0/go.mod h1:XtegFAyX/PfluP4921rXU5IkjkqBCDnUq4W8VCIoKvM=
 howett.net/plist v0.0.0-20181124034731-591f970eefbb/go.mod h1:vMygbs4qMhSZSc4lCUl2OEE+rDiIIJAIdR4m7MiMcm0=
 howett.net/plist v0.0.0-20201026045517-117a925f2150 h1:s7O/9fwMNd6O1yXyQ8zv+U7dfl8k+zdiLWAY8h7XdVI=

--- a/go.sum
+++ b/go.sum
@@ -1810,6 +1810,7 @@ golang.org/x/tools v0.0.0-20200513201620-d5fe73897c97/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200519015757-0d0afa43d58a/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200603131246-cc40288be839/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200609164405-eb789aa7ce50/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200622203043-20e05c1c8ffa/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200624225443-88f3c62a19ff/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
@@ -2036,6 +2037,8 @@ honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.5/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.6 h1:W18jzjh8mfPez+AwGLxmOImucz/IFjpNlrKVnaj2YVc=
 honnef.co/go/tools v0.0.1-2020.1.6/go.mod h1:pyyisuGw24ruLjrr1ddx39WE0y9OooInRzEYLhQB2YY=
+honnef.co/go/tools v0.1.0 h1:AWNL1W1i7f0wNZ8VwOKNJ0sliKvOF/adn0EHenfUh+c=
+honnef.co/go/tools v0.1.0/go.mod h1:XtegFAyX/PfluP4921rXU5IkjkqBCDnUq4W8VCIoKvM=
 howett.net/plist v0.0.0-20181124034731-591f970eefbb/go.mod h1:vMygbs4qMhSZSc4lCUl2OEE+rDiIIJAIdR4m7MiMcm0=
 howett.net/plist v0.0.0-20201026045517-117a925f2150 h1:s7O/9fwMNd6O1yXyQ8zv+U7dfl8k+zdiLWAY8h7XdVI=
 howett.net/plist v0.0.0-20201026045517-117a925f2150/go.mod h1:vMygbs4qMhSZSc4lCUl2OEE+rDiIIJAIdR4m7MiMcm0=

--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -40,6 +40,8 @@ to read resource information from the [GCE metadata server](https://cloud.google
     * host.name
     * host.type
 
+It also can optionally gather tags for the EC2 instance that the collector is running on
+
 * Amazon ECS: Queries the [Task Metadata Endpoint](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint.html) (TMDE) to record information about the current ECS Task. Only TMDE V4 and V3 are supported.
 
     * cloud.provider (aws)
@@ -71,6 +73,18 @@ to read resource information from the [GCE metadata server](https://cloud.google
 detectors: [ <string> ]
 # determines if existing resource attributes should be overridden or preserved, defaults to true
 override: <bool>
+```
+
+EC2 custom configuration example:
+```yaml
+detectors: ["ec2"]
+ec2:
+    # A list of tags to add as resource attributes can be specified
+    tags_to_add:
+        - tag1
+        - tag2
+    # All tags can also be added as resource attributes using this flag
+    add_all_tags: true
 ```
 
 The full list of settings exposed for this extension are documented [here](./config.go)

--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -42,6 +42,18 @@ to read resource information from the [GCE metadata server](https://cloud.google
 
 It also can optionally gather tags for the EC2 instance that the collector is running on
 
+EC2 custom configuration example:
+```yaml
+detectors: ["ec2"]
+ec2:
+    # A list of tags to add as resource attributes can be specified
+    tags_to_add:
+        - tag1
+        - tag2
+    # All tags can also be added as resource attributes using this flag
+    add_all_tags: true
+```
+
 * Amazon ECS: Queries the [Task Metadata Endpoint](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint.html) (TMDE) to record information about the current ECS Task. Only TMDE V4 and V3 are supported.
 
     * cloud.provider (aws)
@@ -73,18 +85,6 @@ It also can optionally gather tags for the EC2 instance that the collector is ru
 detectors: [ <string> ]
 # determines if existing resource attributes should be overridden or preserved, defaults to true
 override: <bool>
-```
-
-EC2 custom configuration example:
-```yaml
-detectors: ["ec2"]
-ec2:
-    # A list of tags to add as resource attributes can be specified
-    tags_to_add:
-        - tag1
-        - tag2
-    # All tags can also be added as resource attributes using this flag
-    add_all_tags: true
 ```
 
 The full list of settings exposed for this extension are documented [here](./config.go)

--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -46,12 +46,11 @@ EC2 custom configuration example:
 ```yaml
 detectors: ["ec2"]
 ec2:
-    # A list of tags to add as resource attributes can be specified
-    tags_to_add:
+    # A list of regex's to match tags to add as resource attributes can be specified
+    tags:
         - tag1
         - tag2
-    # All tags can also be added as resource attributes using this flag
-    add_all_tags: true
+        - label.*
 ```
 
 * Amazon ECS: Queries the [Task Metadata Endpoint](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint.html) (TMDE) to record information about the current ECS Task. Only TMDE V4 and V3 are supported.

--- a/processor/resourcedetectionprocessor/config.go
+++ b/processor/resourcedetectionprocessor/config.go
@@ -18,6 +18,8 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/config/configmodels"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/aws/ec2"
 )
 
 // Config defines configuration for Resource processor.
@@ -32,4 +34,19 @@ type Config struct {
 	// Override indicates whether any existing resource attributes
 	// should be overridden or preserved. Defaults to true.
 	Override bool `mapstructure:"override"`
+	// InternalConfig is a list of settings specific to all detectors
+	DetectorConfigs DetectorConfigs `mapstructure:",squash"`
+}
+
+type DetectorConfigs struct {
+	EC2Config ec2.Config `mapstructure:"ec2"`
+}
+
+func (d *DetectorConfigs) GetConfigFromType(detectorType internal.DetectorType) internal.DetectorConfig{
+	switch detectorType {
+	case ec2.TypeStr:
+		return d.EC2Config
+	default:
+		return nil
+	}
 }

--- a/processor/resourcedetectionprocessor/config.go
+++ b/processor/resourcedetectionprocessor/config.go
@@ -17,9 +17,9 @@ package resourcedetectionprocessor
 import (
 	"time"
 
-	"go.opentelemetry.io/collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/aws/ec2"
+	"go.opentelemetry.io/collector/config/configmodels"
 )
 
 // Config defines configuration for Resource processor.
@@ -38,11 +38,13 @@ type Config struct {
 	DetectorConfigs DetectorConfigs `mapstructure:",squash"`
 }
 
+// DetectorConfigs contains user-specified configurations unique to all individual detectors
 type DetectorConfigs struct {
+	// EC2Config contains user-specified configurations for the EC2 detector
 	EC2Config ec2.Config `mapstructure:"ec2"`
 }
 
-func (d *DetectorConfigs) GetConfigFromType(detectorType internal.DetectorType) internal.DetectorConfig{
+func (d *DetectorConfigs) GetConfigFromType(detectorType internal.DetectorType) internal.DetectorConfig {
 	switch detectorType {
 	case ec2.TypeStr:
 		return d.EC2Config

--- a/processor/resourcedetectionprocessor/config.go
+++ b/processor/resourcedetectionprocessor/config.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/aws/ec2"
+
 	"go.opentelemetry.io/collector/config/configmodels"
 )
 
@@ -34,17 +35,17 @@ type Config struct {
 	// Override indicates whether any existing resource attributes
 	// should be overridden or preserved. Defaults to true.
 	Override bool `mapstructure:"override"`
-	// InternalConfig is a list of settings specific to all detectors
-	DetectorConfigs DetectorConfigs `mapstructure:",squash"`
+	// DetectorConfig is a list of settings specific to all detectors
+	DetectorConfig DetectorConfig `mapstructure:",squash"`
 }
 
-// DetectorConfigs contains user-specified configurations unique to all individual detectors
-type DetectorConfigs struct {
+// DetectorConfig contains user-specified configurations unique to all individual detectors
+type DetectorConfig struct {
 	// EC2Config contains user-specified configurations for the EC2 detector
 	EC2Config ec2.Config `mapstructure:"ec2"`
 }
 
-func (d *DetectorConfigs) GetConfigFromType(detectorType internal.DetectorType) internal.DetectorConfig {
+func (d *DetectorConfig) GetConfigFromType(detectorType internal.DetectorType) internal.DetectorConfig {
 	switch detectorType {
 	case ec2.TypeStr:
 		return d.EC2Config

--- a/processor/resourcedetectionprocessor/config_test.go
+++ b/processor/resourcedetectionprocessor/config_test.go
@@ -63,7 +63,7 @@ func TestLoadConfig(t *testing.T) {
 		Detectors: []string{"env", "ec2"},
 		DetectorConfig: DetectorConfig{
 			EC2Config: ec2.Config{
-				TagsToAdd: []string{"tag1", "tag2"},
+				Tags: []string{"tag1", "tag2"},
 			},
 		},
 		Timeout:  2 * time.Second,
@@ -83,11 +83,11 @@ func TestGetConfigFromType(t *testing.T) {
 			detectorType: ec2.TypeStr,
 			inputDetectorConfig: DetectorConfig{
 				EC2Config: ec2.Config{
-					TagsToAdd: []string{"tag1", "tag2"},
+					Tags: []string{"tag1", "tag2"},
 				},
 			},
 			expectedConfig: ec2.Config{
-				TagsToAdd: []string{"tag1", "tag2"},
+				Tags: []string{"tag1", "tag2"},
 			},
 		},
 		{
@@ -95,7 +95,7 @@ func TestGetConfigFromType(t *testing.T) {
 			detectorType: internal.DetectorType("invalid input"),
 			inputDetectorConfig: DetectorConfig{
 				EC2Config: ec2.Config{
-					TagsToAdd: []string{"tag1", "tag2"},
+					Tags: []string{"tag1", "tag2"},
 				},
 			},
 			expectedConfig: nil,

--- a/processor/resourcedetectionprocessor/config_test.go
+++ b/processor/resourcedetectionprocessor/config_test.go
@@ -19,12 +19,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/aws/ec2"
+
 	"github.com/stretchr/testify/assert"
+
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/config/configtest"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/aws/ec2"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -59,13 +61,13 @@ func TestLoadConfig(t *testing.T) {
 			NameVal: "resourcedetection/ec2",
 		},
 		Detectors: []string{"env", "ec2"},
-		DetectorConfigs: DetectorConfigs {
+		DetectorConfig: DetectorConfig{
 			EC2Config: ec2.Config{
 				TagsToAdd: []string{"tag1", "tag2"},
 			},
 		},
-		Timeout:   2 * time.Second,
-		Override:  false,
+		Timeout:  2 * time.Second,
+		Override: false,
 	})
 }
 
@@ -73,13 +75,13 @@ func TestGetConfigFromType(t *testing.T) {
 	tests := []struct {
 		name                string
 		detectorType        internal.DetectorType
-		inputDetectorConfig DetectorConfigs
+		inputDetectorConfig DetectorConfig
 		expectedConfig      internal.DetectorConfig
 	}{
 		{
-			name: "Get EC2 Config",
+			name:         "Get EC2 Config",
 			detectorType: ec2.TypeStr,
-			inputDetectorConfig: DetectorConfigs {
+			inputDetectorConfig: DetectorConfig{
 				EC2Config: ec2.Config{
 					TagsToAdd: []string{"tag1", "tag2"},
 				},
@@ -87,11 +89,11 @@ func TestGetConfigFromType(t *testing.T) {
 			expectedConfig: ec2.Config{
 				TagsToAdd: []string{"tag1", "tag2"},
 			},
-		}, 
+		},
 		{
-			name: "Get Nil Config",
+			name:         "Get Nil Config",
 			detectorType: internal.DetectorType("invalid input"),
-			inputDetectorConfig: DetectorConfigs {
+			inputDetectorConfig: DetectorConfig{
 				EC2Config: ec2.Config{
 					TagsToAdd: []string{"tag1", "tag2"},
 				},

--- a/processor/resourcedetectionprocessor/factory.go
+++ b/processor/resourcedetectionprocessor/factory.go
@@ -154,7 +154,7 @@ func (f *factory) getResourceDetectionProcessor(
 ) (*resourceDetectionProcessor, error) {
 	oCfg := cfg.(*Config)
 
-	provider, err := f.getResourceProvider(params, cfg.Name(), oCfg.Timeout, oCfg.Detectors)
+	provider, err := f.getResourceProvider(params, cfg.Name(), oCfg.Timeout, oCfg.Detectors, oCfg.DetectorConfigs)
 	if err != nil {
 		return nil, err
 	}
@@ -170,6 +170,7 @@ func (f *factory) getResourceProvider(
 	processorName string,
 	timeout time.Duration,
 	configuredDetectors []string,
+	detectorConfigs DetectorConfigs,
 ) (*internal.ResourceProvider, error) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
@@ -183,7 +184,7 @@ func (f *factory) getResourceProvider(
 		detectorTypes = append(detectorTypes, internal.DetectorType(strings.TrimSpace(key)))
 	}
 
-	provider, err := f.resourceProviderFactory.CreateResourceProvider(params, timeout, detectorTypes...)
+	provider, err := f.resourceProviderFactory.CreateResourceProvider(params, timeout, &detectorConfigs, detectorTypes...)
 	if err != nil {
 		return nil, err
 	}

--- a/processor/resourcedetectionprocessor/factory.go
+++ b/processor/resourcedetectionprocessor/factory.go
@@ -154,7 +154,7 @@ func (f *factory) getResourceDetectionProcessor(
 ) (*resourceDetectionProcessor, error) {
 	oCfg := cfg.(*Config)
 
-	provider, err := f.getResourceProvider(params, cfg.Name(), oCfg.Timeout, oCfg.Detectors, oCfg.DetectorConfigs)
+	provider, err := f.getResourceProvider(params, cfg.Name(), oCfg.Timeout, oCfg.Detectors, oCfg.DetectorConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +170,7 @@ func (f *factory) getResourceProvider(
 	processorName string,
 	timeout time.Duration,
 	configuredDetectors []string,
-	detectorConfigs DetectorConfigs,
+	detectorConfigs DetectorConfig,
 ) (*internal.ResourceProvider, error) {
 	f.lock.Lock()
 	defer f.lock.Unlock()

--- a/processor/resourcedetectionprocessor/go.mod
+++ b/processor/resourcedetectionprocessor/go.mod
@@ -11,4 +11,5 @@ require (
 	go.opentelemetry.io/collector v0.17.0
 	go.uber.org/zap v1.16.0
 	google.golang.org/grpc/examples v0.0.0-20200728194956-1c32b02682df // indirect
+	honnef.co/go/tools v0.1.0 // indirect
 )

--- a/processor/resourcedetectionprocessor/go.sum
+++ b/processor/resourcedetectionprocessor/go.sum
@@ -1275,6 +1275,7 @@ golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200513201620-d5fe73897c97/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200603131246-cc40288be839/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200609164405-eb789aa7ce50/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
@@ -1458,6 +1459,8 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.6 h1:W18jzjh8mfPez+AwGLxmOImucz/IFjpNlrKVnaj2YVc=
 honnef.co/go/tools v0.0.1-2020.1.6/go.mod h1:pyyisuGw24ruLjrr1ddx39WE0y9OooInRzEYLhQB2YY=
+honnef.co/go/tools v0.1.0 h1:AWNL1W1i7f0wNZ8VwOKNJ0sliKvOF/adn0EHenfUh+c=
+honnef.co/go/tools v0.1.0/go.mod h1:XtegFAyX/PfluP4921rXU5IkjkqBCDnUq4W8VCIoKvM=
 k8s.io/api v0.19.2 h1:q+/krnHWKsL7OBZg/rxnycsl9569Pud76UJ77MvKXms=
 k8s.io/api v0.19.2/go.mod h1:IQpK0zFQ1xc5iNIQPqzgoOwuFugaYHK4iCknlAQP9nI=
 k8s.io/apimachinery v0.19.2 h1:5Gy9vQpAGTKHPVOh5c4plE274X8D/6cuEiTO2zve7tc=

--- a/processor/resourcedetectionprocessor/internal/aws/ec2/config.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/config.go
@@ -14,11 +14,9 @@
 
 package ec2
 
+// Config defines user-specified configurations unique to the EC2 detector
 type Config struct {
-	// TagsToAdd is a list of ec2 instance tags that users want
+	// Tags is a list of regex's to match ec2 instance tags that users want
 	// to add as resource attributes to processed data
-	TagsToAdd []string `mapstructure:"tags_to_add"`
-	// AddAllTags is a boolean flag that adds all detected tags
-	// as resource attributes, and overrides the list TagsToAdd
-	AddAllTags bool `mapstructure:"add_all_tags"`
+	Tags []string `mapstructure:"tags"`
 }

--- a/processor/resourcedetectionprocessor/internal/aws/ec2/config.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/config.go
@@ -1,0 +1,24 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ec2
+
+type Config struct {
+	// TagsToAdd is a list of ec2 instance tags that users want
+	// to add as resource attributes to processed data
+	TagsToAdd []string `mapstructure:"tags_to_add"`
+	// AddAllTags is a boolean flag that adds all detected tags
+	// as resource attributes, and overrides the list TagsToAdd
+	AddAllTags bool `mapstructure:"add_all_tags"`
+}

--- a/processor/resourcedetectionprocessor/internal/aws/ec2/ec2_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/ec2_test.go
@@ -60,7 +60,7 @@ func (mm mockMetadata) hostname(ctx context.Context) (string, error) {
 }
 
 func TestNewDetector(t *testing.T) {
-	detector, err := NewDetector(component.ProcessorCreateParams{Logger: zap.NewNop()})
+	detector, err := NewDetector(component.ProcessorCreateParams{Logger: zap.NewNop()}, Config{})
 	assert.NotNil(t, detector)
 	assert.NoError(t, err)
 }

--- a/processor/resourcedetectionprocessor/internal/aws/ec2/ec2_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/ec2_test.go
@@ -204,7 +204,7 @@ func TestEC2Tags(t *testing.T) {
 		{
 			name: "success case one tag specified",
 			cfg: Config{
-				TagsToAdd: []string{"tag1"},
+				Tags: []string{"tag1"},
 			},
 			resourceID: "resource1",
 			expectedOutput: map[string]string{
@@ -215,20 +215,7 @@ func TestEC2Tags(t *testing.T) {
 		{
 			name: "success case all tags",
 			cfg: Config{
-				AddAllTags: true,
-			},
-			resourceID: "resource1",
-			expectedOutput: map[string]string{
-				"tag1": "val1",
-				"tag2": "val2",
-			},
-			shouldError: false,
-		},
-		{
-			name: "success case all tags override list",
-			cfg: Config{
-				AddAllTags: true,
-				TagsToAdd:  []string{"tag2"},
+				Tags: []string{".*"},
 			},
 			resourceID: "resource1",
 			expectedOutput: map[string]string{
@@ -240,10 +227,21 @@ func TestEC2Tags(t *testing.T) {
 		{
 			name: "error case in DescribeTags",
 			cfg: Config{
-				AddAllTags: true,
-				TagsToAdd:  []string{"tag2"},
+				Tags: []string{"tag2"},
 			},
 			resourceID: "error",
+			expectedOutput: map[string]string{
+				"tag1": "val1",
+				"tag2": "val2",
+			},
+			shouldError: true,
+		},
+		{
+			name: "error case invalid regex",
+			cfg: Config{
+				Tags: []string{"*"},
+			},
+			resourceID: "resource1",
 			expectedOutput: map[string]string{
 				"tag1": "val1",
 				"tag2": "val2",

--- a/processor/resourcedetectionprocessor/internal/aws/ec2/ec2_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/ec2_test.go
@@ -22,12 +22,15 @@ import (
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.uber.org/zap"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
 )
 
 type mockMetadata struct {
@@ -166,12 +169,12 @@ func TestDetector_Detect(t *testing.T) {
 
 // Define a mock client to mock connecting to an EC2 instance
 type mockEC2Client struct {
-    ec2iface.EC2API
+	ec2iface.EC2API
 }
 
 // override the DescribeTags function to mock the output from an actual EC2 instance
 func (m *mockEC2Client) DescribeTags(input *ec2.DescribeTagsInput) (*ec2.DescribeTagsOutput, error) {
-	if *input.Filters[0].Values[0] == "error"{
+	if *input.Filters[0].Values[0] == "error" {
 		return nil, errors.New("error")
 	}
 
@@ -225,7 +228,7 @@ func TestEC2Tags(t *testing.T) {
 			name: "success case all tags override list",
 			cfg: Config{
 				AddAllTags: true,
-				TagsToAdd: []string{"tag2"},
+				TagsToAdd:  []string{"tag2"},
 			},
 			resourceID: "resource1",
 			expectedOutput: map[string]string{
@@ -238,7 +241,7 @@ func TestEC2Tags(t *testing.T) {
 			name: "error case in DescribeTags",
 			cfg: Config{
 				AddAllTags: true,
-				TagsToAdd: []string{"tag2"},
+				TagsToAdd:  []string{"tag2"},
 			},
 			resourceID: "error",
 			expectedOutput: map[string]string{

--- a/processor/resourcedetectionprocessor/internal/aws/ecs/ecs.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ecs/ecs.go
@@ -41,7 +41,7 @@ type Detector struct {
 	provider ecsMetadataProvider
 }
 
-func NewDetector(params component.ProcessorCreateParams) (internal.Detector, error) {
+func NewDetector(params component.ProcessorCreateParams, _ internal.DetectorConfig) (internal.Detector, error) {
 	return &Detector{provider: &ecsMetadataProviderImpl{logger: params.Logger, client: &http.Client{}}}, nil
 }
 

--- a/processor/resourcedetectionprocessor/internal/aws/ecs/ecs_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ecs/ecs_test.go
@@ -58,7 +58,7 @@ func (md *mockMetaDataProvider) fetchContainerMetaData(string) (*Container, erro
 }
 
 func Test_ecsNewDetector(t *testing.T) {
-	d, err := NewDetector(component.ProcessorCreateParams{Logger: zap.NewNop()})
+	d, err := NewDetector(component.ProcessorCreateParams{Logger: zap.NewNop()}, nil)
 
 	assert.NotNil(t, d)
 	assert.Nil(t, err)
@@ -66,7 +66,7 @@ func Test_ecsNewDetector(t *testing.T) {
 
 func Test_detectorReturnsIfNoEnvVars(t *testing.T) {
 	os.Clearenv()
-	d, _ := NewDetector(component.ProcessorCreateParams{Logger: zap.NewNop()})
+	d, _ := NewDetector(component.ProcessorCreateParams{Logger: zap.NewNop()}, nil)
 	res, err := d.Detect(context.TODO())
 
 	assert.Nil(t, err)

--- a/processor/resourcedetectionprocessor/internal/aws/elasticbeanstalk/elasticbeanstalk.go
+++ b/processor/resourcedetectionprocessor/internal/aws/elasticbeanstalk/elasticbeanstalk.go
@@ -46,7 +46,7 @@ type EbMetaData struct {
 	VersionLabel    string `json:"version_label"`
 }
 
-func NewDetector(component.ProcessorCreateParams) (internal.Detector, error) {
+func NewDetector(component.ProcessorCreateParams, internal.DetectorConfig) (internal.Detector, error) {
 	return &Detector{fs: &ebFileSystem{}}, nil
 }
 

--- a/processor/resourcedetectionprocessor/internal/aws/elasticbeanstalk/elasticbeanstalk_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/elasticbeanstalk/elasticbeanstalk_test.go
@@ -53,7 +53,7 @@ func (mfs *mockFileSystem) IsWindows() bool {
 }
 
 func Test_newDetector(t *testing.T) {
-	d, err := NewDetector(component.ProcessorCreateParams{Logger: zap.NewNop()})
+	d, err := NewDetector(component.ProcessorCreateParams{Logger: zap.NewNop()}, nil)
 
 	assert.Nil(t, err)
 	assert.NotNil(t, d)

--- a/processor/resourcedetectionprocessor/internal/env/env.go
+++ b/processor/resourcedetectionprocessor/internal/env/env.go
@@ -41,7 +41,7 @@ var _ internal.Detector = (*Detector)(nil)
 
 type Detector struct{}
 
-func NewDetector(component.ProcessorCreateParams) (internal.Detector, error) {
+func NewDetector(component.ProcessorCreateParams, internal.DetectorConfig) (internal.Detector, error) {
 	return &Detector{}, nil
 }
 

--- a/processor/resourcedetectionprocessor/internal/env/env_test.go
+++ b/processor/resourcedetectionprocessor/internal/env/env_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestNewDetector(t *testing.T) {
-	d, err := NewDetector(component.ProcessorCreateParams{Logger: zap.NewNop()})
+	d, err := NewDetector(component.ProcessorCreateParams{Logger: zap.NewNop()}, nil)
 	assert.NotNil(t, d)
 	assert.NoError(t, err)
 }

--- a/processor/resourcedetectionprocessor/internal/gcp/gce/gce.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/gce/gce.go
@@ -37,7 +37,7 @@ type Detector struct {
 	metadata gceMetadata
 }
 
-func NewDetector(component.ProcessorCreateParams) (internal.Detector, error) {
+func NewDetector(component.ProcessorCreateParams, internal.DetectorConfig) (internal.Detector, error) {
 	return &Detector{metadata: &gceMetadataImpl{}}, nil
 }
 

--- a/processor/resourcedetectionprocessor/internal/gcp/gce/gce_test.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/gce/gce_test.go
@@ -68,7 +68,7 @@ func (m *mockMetadata) Get(suffix string) (string, error) {
 }
 
 func TestNewDetector(t *testing.T) {
-	d, err := NewDetector(component.ProcessorCreateParams{Logger: zap.NewNop()})
+	d, err := NewDetector(component.ProcessorCreateParams{Logger: zap.NewNop()}, nil)
 	assert.NotNil(t, d)
 	assert.NoError(t, err)
 }

--- a/processor/resourcedetectionprocessor/internal/resourcedetection.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection.go
@@ -33,7 +33,13 @@ type Detector interface {
 	Detect(ctx context.Context) (pdata.Resource, error)
 }
 
-type DetectorFactory func(component.ProcessorCreateParams) (Detector, error)
+type DetectorConfig interface {}
+
+type InternalDetectorConfigs interface {
+	GetConfigFromType(DetectorType) DetectorConfig
+}
+
+type DetectorFactory func(component.ProcessorCreateParams, DetectorConfig) (Detector, error)
 
 type ResourceProviderFactory struct {
 	// detectors holds all possible detector types.
@@ -47,8 +53,9 @@ func NewProviderFactory(detectors map[DetectorType]DetectorFactory) *ResourcePro
 func (f *ResourceProviderFactory) CreateResourceProvider(
 	params component.ProcessorCreateParams,
 	timeout time.Duration,
+	detectorConfigs InternalDetectorConfigs,
 	detectorTypes ...DetectorType) (*ResourceProvider, error) {
-	detectors, err := f.getDetectors(params, detectorTypes)
+	detectors, err := f.getDetectors(params, detectorConfigs, detectorTypes)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +64,7 @@ func (f *ResourceProviderFactory) CreateResourceProvider(
 	return provider, nil
 }
 
-func (f *ResourceProviderFactory) getDetectors(params component.ProcessorCreateParams, detectorTypes []DetectorType) ([]Detector, error) {
+func (f *ResourceProviderFactory) getDetectors(params component.ProcessorCreateParams, detectorConfigs InternalDetectorConfigs, detectorTypes []DetectorType) ([]Detector, error) {
 	detectors := make([]Detector, 0, len(detectorTypes))
 	for _, detectorType := range detectorTypes {
 		detectorFactory, ok := f.detectors[detectorType]
@@ -65,7 +72,7 @@ func (f *ResourceProviderFactory) getDetectors(params component.ProcessorCreateP
 			return nil, fmt.Errorf("invalid detector key: %v", detectorType)
 		}
 
-		detector, err := detectorFactory(params)
+		detector, err := detectorFactory(params, detectorConfigs.GetConfigFromType(detectorType))
 		if err != nil {
 			return nil, fmt.Errorf("failed creating detector type %q: %w", detectorType, err)
 		}

--- a/processor/resourcedetectionprocessor/internal/resourcedetection.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection.go
@@ -33,9 +33,9 @@ type Detector interface {
 	Detect(ctx context.Context) (pdata.Resource, error)
 }
 
-type DetectorConfig interface {}
+type DetectorConfig interface{}
 
-type InternalDetectorConfigs interface {
+type ResourceDetectorConfig interface {
 	GetConfigFromType(DetectorType) DetectorConfig
 }
 
@@ -53,7 +53,7 @@ func NewProviderFactory(detectors map[DetectorType]DetectorFactory) *ResourcePro
 func (f *ResourceProviderFactory) CreateResourceProvider(
 	params component.ProcessorCreateParams,
 	timeout time.Duration,
-	detectorConfigs InternalDetectorConfigs,
+	detectorConfigs ResourceDetectorConfig,
 	detectorTypes ...DetectorType) (*ResourceProvider, error) {
 	detectors, err := f.getDetectors(params, detectorConfigs, detectorTypes)
 	if err != nil {
@@ -64,7 +64,7 @@ func (f *ResourceProviderFactory) CreateResourceProvider(
 	return provider, nil
 }
 
-func (f *ResourceProviderFactory) getDetectors(params component.ProcessorCreateParams, detectorConfigs InternalDetectorConfigs, detectorTypes []DetectorType) ([]Detector, error) {
+func (f *ResourceProviderFactory) getDetectors(params component.ProcessorCreateParams, detectorConfigs ResourceDetectorConfig, detectorTypes []DetectorType) ([]Detector, error) {
 	detectors := make([]Detector, 0, len(detectorTypes))
 	for _, detectorType := range detectorTypes {
 		detectorFactory, ok := f.detectors[detectorType]

--- a/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
@@ -39,6 +39,12 @@ func (p *MockDetector) Detect(ctx context.Context) (pdata.Resource, error) {
 	return args.Get(0).(pdata.Resource), args.Error(1)
 }
 
+type MockDetectorConfigs struct {}
+
+func (d *MockDetectorConfigs) GetConfigFromType(detectorType DetectorType) DetectorConfig {
+	return nil
+}
+
 func TestDetect(t *testing.T) {
 	tests := []struct {
 		name              string
@@ -82,14 +88,14 @@ func TestDetect(t *testing.T) {
 				md.On("Detect").Return(res, nil)
 
 				mockDetectorType := DetectorType(fmt.Sprintf("mockdetector%v", i))
-				mockDetectors[mockDetectorType] = func(component.ProcessorCreateParams) (Detector, error) {
+				mockDetectors[mockDetectorType] = func(component.ProcessorCreateParams, DetectorConfig) (Detector, error) {
 					return md, nil
 				}
 				mockDetectorTypes = append(mockDetectorTypes, mockDetectorType)
 			}
 
 			f := NewProviderFactory(mockDetectors)
-			p, err := f.CreateResourceProvider(component.ProcessorCreateParams{Logger: zap.NewNop()}, time.Second, mockDetectorTypes...)
+			p, err := f.CreateResourceProvider(component.ProcessorCreateParams{Logger: zap.NewNop()}, time.Second, &MockDetectorConfigs{}, mockDetectorTypes...)
 			require.NoError(t, err)
 
 			got, err := p.Get(context.Background())
@@ -105,18 +111,18 @@ func TestDetect(t *testing.T) {
 func TestDetectResource_InvalidDetectorType(t *testing.T) {
 	mockDetectorKey := DetectorType("mock")
 	p := NewProviderFactory(map[DetectorType]DetectorFactory{})
-	_, err := p.CreateResourceProvider(component.ProcessorCreateParams{Logger: zap.NewNop()}, time.Second, mockDetectorKey)
+	_, err := p.CreateResourceProvider(component.ProcessorCreateParams{Logger: zap.NewNop()}, time.Second, &MockDetectorConfigs{}, mockDetectorKey)
 	require.EqualError(t, err, fmt.Sprintf("invalid detector key: %v", mockDetectorKey))
 }
 
 func TestDetectResource_DetectoryFactoryError(t *testing.T) {
 	mockDetectorKey := DetectorType("mock")
 	p := NewProviderFactory(map[DetectorType]DetectorFactory{
-		mockDetectorKey: func(component.ProcessorCreateParams) (Detector, error) {
+		mockDetectorKey: func(component.ProcessorCreateParams, DetectorConfig) (Detector, error) {
 			return nil, errors.New("creation failed")
 		},
 	})
-	_, err := p.CreateResourceProvider(component.ProcessorCreateParams{Logger: zap.NewNop()}, time.Second, mockDetectorKey)
+	_, err := p.CreateResourceProvider(component.ProcessorCreateParams{Logger: zap.NewNop()}, time.Second, &MockDetectorConfigs{}, mockDetectorKey)
 	require.EqualError(t, err, fmt.Sprintf("failed creating detector type %q: %v", mockDetectorKey, "creation failed"))
 }
 

--- a/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
@@ -39,9 +39,9 @@ func (p *MockDetector) Detect(ctx context.Context) (pdata.Resource, error) {
 	return args.Get(0).(pdata.Resource), args.Error(1)
 }
 
-type MockDetectorConfigs struct {}
+type mockDetectorConfig struct{}
 
-func (d *MockDetectorConfigs) GetConfigFromType(detectorType DetectorType) DetectorConfig {
+func (d *mockDetectorConfig) GetConfigFromType(detectorType DetectorType) DetectorConfig {
 	return nil
 }
 
@@ -95,7 +95,7 @@ func TestDetect(t *testing.T) {
 			}
 
 			f := NewProviderFactory(mockDetectors)
-			p, err := f.CreateResourceProvider(component.ProcessorCreateParams{Logger: zap.NewNop()}, time.Second, &MockDetectorConfigs{}, mockDetectorTypes...)
+			p, err := f.CreateResourceProvider(component.ProcessorCreateParams{Logger: zap.NewNop()}, time.Second, &mockDetectorConfig{}, mockDetectorTypes...)
 			require.NoError(t, err)
 
 			got, err := p.Get(context.Background())
@@ -111,7 +111,7 @@ func TestDetect(t *testing.T) {
 func TestDetectResource_InvalidDetectorType(t *testing.T) {
 	mockDetectorKey := DetectorType("mock")
 	p := NewProviderFactory(map[DetectorType]DetectorFactory{})
-	_, err := p.CreateResourceProvider(component.ProcessorCreateParams{Logger: zap.NewNop()}, time.Second, &MockDetectorConfigs{}, mockDetectorKey)
+	_, err := p.CreateResourceProvider(component.ProcessorCreateParams{Logger: zap.NewNop()}, time.Second, &mockDetectorConfig{}, mockDetectorKey)
 	require.EqualError(t, err, fmt.Sprintf("invalid detector key: %v", mockDetectorKey))
 }
 
@@ -122,7 +122,7 @@ func TestDetectResource_DetectoryFactoryError(t *testing.T) {
 			return nil, errors.New("creation failed")
 		},
 	})
-	_, err := p.CreateResourceProvider(component.ProcessorCreateParams{Logger: zap.NewNop()}, time.Second, &MockDetectorConfigs{}, mockDetectorKey)
+	_, err := p.CreateResourceProvider(component.ProcessorCreateParams{Logger: zap.NewNop()}, time.Second, &mockDetectorConfig{}, mockDetectorKey)
 	require.EqualError(t, err, fmt.Sprintf("failed creating detector type %q: %v", mockDetectorKey, "creation failed"))
 }
 

--- a/processor/resourcedetectionprocessor/internal/system/system.go
+++ b/processor/resourcedetectionprocessor/internal/system/system.go
@@ -38,7 +38,7 @@ type Detector struct {
 }
 
 // NewDetector creates a new system metadata detector
-func NewDetector(component.ProcessorCreateParams) (internal.Detector, error) {
+func NewDetector(component.ProcessorCreateParams, internal.DetectorConfig) (internal.Detector, error) {
 	return &Detector{provider: &systemMetadataImpl{}}, nil
 }
 

--- a/processor/resourcedetectionprocessor/internal/system/system_test.go
+++ b/processor/resourcedetectionprocessor/internal/system/system_test.go
@@ -44,7 +44,7 @@ func (m *mockMetadata) OSType() (string, error) {
 }
 
 func TestNewDetector(t *testing.T) {
-	d, err := NewDetector(component.ProcessorCreateParams{Logger: zap.NewNop()})
+	d, err := NewDetector(component.ProcessorCreateParams{Logger: zap.NewNop()}, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, d)
 }

--- a/processor/resourcedetectionprocessor/resourcedetection_processor_test.go
+++ b/processor/resourcedetectionprocessor/resourcedetection_processor_test.go
@@ -162,7 +162,7 @@ func TestResourceProcessor(t *testing.T) {
 			md1 := &MockDetector{}
 			md1.On("Detect").Return(tt.detectedResource, tt.detectedError)
 			factory.resourceProviderFactory = internal.NewProviderFactory(
-				map[internal.DetectorType]internal.DetectorFactory{"mock": func(component.ProcessorCreateParams) (internal.Detector, error) {
+				map[internal.DetectorType]internal.DetectorFactory{"mock": func(component.ProcessorCreateParams, internal.DetectorConfig) (internal.Detector, error) {
 					return md1, nil
 				}})
 

--- a/processor/resourcedetectionprocessor/testdata/config.yaml
+++ b/processor/resourcedetectionprocessor/testdata/config.yaml
@@ -12,7 +12,7 @@ processors:
     timeout: 2s
     override: false
     ec2:
-      tags_to_add:
+      tags:
         - tag1
         - tag2
   resourcedetection/ecs:

--- a/processor/resourcedetectionprocessor/testdata/config.yaml
+++ b/processor/resourcedetectionprocessor/testdata/config.yaml
@@ -11,6 +11,10 @@ processors:
     detectors: [env, ec2]
     timeout: 2s
     override: false
+    ec2:
+      tags_to_add:
+        - tag1
+        - tag2
   resourcedetection/ecs:
     detectors: [env, ecs]
     timeout: 2s


### PR DESCRIPTION
**Description:** 
This PR adds logic in the EC2 resource detector to gather tags associated with the EC2 instance and add them as resource attributes. This also includes some changes that allow for user configurations to be passed into individual detectors.

In the future if we want custom configurations to be passed into other detectors, we simply add a `config.go` in the detector's directory with a struct for it, import it in the root `config.go` to point to it, and then use the variable passed into the detector's `NewDetector` function

Users can specify a list of regex values to match the EC2 instance tags that they want to add as resource attributes.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1627

**Testing:**
Unit tests have been added using the AWS Go SDK EC2 mock interface

**Documentation:** 
README has been updated to show how to use the new custom EC2 configurations