### PR TITLE
Renamed service.AppSettings calls to service.CollectorSettings

### DIFF
--- a/cmd/otelcontribcol/main.go
+++ b/cmd/otelcontribcol/main.go
@@ -39,20 +39,20 @@ func main() {
 		Version:     version.Version,
 	}
 
-	if err := run(service.AppSettings{BuildInfo: info, Factories: factories}); err != nil {
+	if err := run(service.CollectorSettings{BuildInfo: info, Factories: factories}); err != nil {
 		log.Fatal(err)
 	}
 }
 
-func runInteractive(params service.AppSettings) error {
+func runInteractive(params service.CollectorSettings) error {
 	app, err := service.New(params)
 	if err != nil {
-		return fmt.Errorf("failed to construct the application: %w", err)
+		return fmt.Errorf("failed to construct the collector server: %w", err)
 	}
 
 	err = app.Run()
 	if err != nil {
-		return fmt.Errorf("application run finished with error: %w", err)
+		return fmt.Errorf("collector server run finished with error: %w", err)
 	}
 
 	return nil

--- a/cmd/otelcontribcol/main_others.go
+++ b/cmd/otelcontribcol/main_others.go
@@ -18,6 +18,6 @@ package main
 
 import "go.opentelemetry.io/collector/service"
 
-func run(params service.AppSettings) error {
+func run(params service.CollectorSettings) error {
 	return runInteractive(params)
 }

--- a/cmd/otelcontribcol/main_windows.go
+++ b/cmd/otelcontribcol/main_windows.go
@@ -24,7 +24,7 @@ import (
 	"golang.org/x/sys/windows/svc"
 )
 
-func run(params service.AppSettings) error {
+func run(params service.CollectorSettings) error {
 	if useInteractiveMode, err := checkUseInteractiveMode(); err != nil {
 		return err
 	} else if useInteractiveMode {
@@ -50,7 +50,7 @@ func checkUseInteractiveMode() (bool, error) {
 	}
 }
 
-func runService(params service.AppSettings) error {
+func runService(params service.CollectorSettings) error {
 	// do not need to supply service name when startup is invoked through Service Control Manager directly
 	if err := svc.Run("", service.NewWindowsService(params)); err != nil {
 		return fmt.Errorf("failed to start service: %w", err)


### PR DESCRIPTION
**Description:** 
Renamed calls to API that will change from service.AppSettings to service.CollectorSettings in the core repo. To be merged with PR 3268 on opentelemetry-collector.

**Link to tracking Issue:** 
3175

**Testing:**
Local `make` with `make otel-from-tree` using the corresponding changes in PR 3268 returns a clean make.

**Documentation:**
- [ ] Merge PR 3268 in the core repo.
- [ ] Add to the change log if necessary.