### PR TITLE
fix: TLS config in readme and yaml

### DIFF
--- a/examples/demo/otel-collector-config.yaml
+++ b/examples/demo/otel-collector-config.yaml
@@ -17,7 +17,8 @@ exporters:
 
   jaeger:
     endpoint: jaeger-all-in-one:14250
-    insecure: true
+    tls:
+      insecure: true
 
 processors:
   batch:

--- a/exporter/datadogexporter/example/example_k8s_manifest.yaml
+++ b/exporter/datadogexporter/example/example_k8s_manifest.yaml
@@ -33,7 +33,8 @@ data:
     exporters:
       otlp:
         endpoint: "otel-collector.default:4317"
-        insecure: true
+        tls:
+          insecure: true
     processors:
       batch:
       memory_limiter:

--- a/exporter/elasticexporter/README.md
+++ b/exporter/elasticexporter/README.md
@@ -54,7 +54,8 @@ exporters:
 exporters:
   otlp/elastic:
       endpoint: "localhost:8200"
-      insecure: true
+      tls:
+        insecure: true
 ```
 
 ## Migration
@@ -121,10 +122,11 @@ Complete documentation is available on [Elastic.co](https://www.elastic.co/guide
 - `apm_server_url` (required): Elastic APM Server URL.
 - `api_key` (optional): credential for API Key authorization, if enabled in Elastic APM Server.
 - `secret_token` (optional): credential for Secret Token authorization, if enabled in Elastic APM Server.
-- `ca_file` (optional): root Certificate Authority (CA) certificate, for verifying the server's identity, if TLS is enabled.
-- `cert_file` (optional): client TLS certificate.
-- `key_file` (optional): client TLS key.
-- `insecure` (optional): disable verification of the server's identity, if TLS is enabled.
+- `tls:`
+  - `ca_file` (optional): root Certificate Authority (CA) certificate, for verifying the server's identity, if TLS is enabled.
+  - `cert_file` (optional): client TLS certificate.
+  - `key_file` (optional): client TLS key.
+  - `insecure` (optional): disable verification of the server's identity, if TLS is enabled.
 
 ### Example
 

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -54,6 +54,8 @@ This exporter supports sending OpenTelemetry logs to [Elasticsearch](https://www
 - `user` (optional): Username used for HTTP Basic Authentication.
 - `password` (optional): Password used for HTTP Basic Authentication.
 - `api_key` (optional):  Authorization [API Key](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html).
+
+### TLS settings
 - `ca_file` (optional): Root Certificate Authority (CA) certificate, for
   verifying the server's identity, if TLS is enabled.
 - `cert_file` (optional): Client TLS certificate.

--- a/exporter/jaegerexporter/README.md
+++ b/exporter/jaegerexporter/README.md
@@ -15,15 +15,17 @@ using the gRPC protocol. The valid syntax is described
 
 By default, TLS is enabled:
 
-- `insecure` (default = `false`): whether to enable client transport security for
-  the exporter's connection.
+- `tls:`
+  - `insecure` (default = `false`): whether to enable client transport security for
+    the exporter's connection.
 
 As a result, the following parameters are also required:
 
-- `cert_file` (no default): path to the TLS cert to use for TLS required connections. Should
-  only be used if `insecure` is set to false.
-- `key_file` (no default): path to the TLS key to use for TLS required connections. Should
-  only be used if `insecure` is set to false.
+- `tls:`
+  - `cert_file` (no default): path to the TLS cert to use for TLS required connections. Should
+    only be used if `insecure` is set to false.
+  - `key_file` (no default): path to the TLS key to use for TLS required connections. Should
+    only be used if `insecure` is set to false.
 
 Example:
 
@@ -31,11 +33,13 @@ Example:
 exporters:
   jaeger:
     endpoint: jaeger-all-in-one:14250
-    cert_file: file.cert
-    key_file: file.key
+    tls:
+      cert_file: file.cert
+      key_file: file.key
   jaeger/2:
     endpoint: jaeger-all-in-one:14250
-    insecure: true
+    tls:
+      insecure: true
 ```
 
 ## Advanced Configuration

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -96,7 +96,8 @@ exporters:
     protocol:
       otlp:
         timeout: 1s
-        insecure: true
+        tls:
+          insecure: true
     resolver:
       static:
         hostnames:

--- a/exporter/loadbalancingexporter/example/otel-agent-config.yaml
+++ b/exporter/loadbalancingexporter/example/otel-agent-config.yaml
@@ -12,7 +12,8 @@ exporters:
     protocol:
       otlp:
         timeout: 1s
-        insecure: true
+        tls:
+          insecure: true
     resolver:
       static:
         hostnames:

--- a/exporter/opencensusexporter/README.md
+++ b/exporter/opencensusexporter/README.md
@@ -15,15 +15,17 @@ using the gRPC protocol. The valid syntax is described
 
 By default, TLS is enabled:
 
-- `insecure` (default = `false`): whether to enable client transport security for
-  the exporter's connection.
+- `tls:`
+  - `insecure` (default = `false`): whether to enable client transport security for
+    the exporter's connection.
 
 As a result, the following parameters are also required:
 
-- `cert_file` (no default): path to the TLS cert to use for TLS required connections. Should
-  only be used if `insecure` is set to false.
-- `key_file` (no default): path to the TLS key to use for TLS required connections. Should
-  only be used if `insecure` is set to false.
+- `tls:`
+  - `cert_file` (no default): path to the TLS cert to use for TLS required connections. Should
+    only be used if `insecure` is set to false.
+  - `key_file` (no default): path to the TLS key to use for TLS required connections. Should
+    only be used if `insecure` is set to false.
 
 Example:
 
@@ -31,11 +33,13 @@ Example:
 exporters:
   opencensus:
     endpoint: opencensus2:55678
-    cert_file: file.cert
-    key_file: file.key
+    tls:
+      cert_file: file.cert
+      key_file: file.key
   otlp/2:
     endpoint: opencensus2:55678
-    insecure: true
+    tls:
+      insecure: true
 ```
 
 ## Advanced Configuration

--- a/exporter/prometheusremotewriteexporter/README.md
+++ b/exporter/prometheusremotewriteexporter/README.md
@@ -22,15 +22,17 @@ The following settings are required:
 
 By default, TLS is enabled:
 
-- `insecure` (default = `false`): whether to enable client transport security for
-  the exporter's connection.
+- `tls:`
+  - `insecure` (default = `false`): whether to enable client transport security for
+    the exporter's connection.
 
 As a result, the following parameters are also required:
 
-- `cert_file` (no default): path to the TLS cert to use for TLS required connections. Should
-  only be used if `insecure` is set to false.
-- `key_file` (no default): path to the TLS key to use for TLS required connections. Should
-  only be used if `insecure` is set to false.
+- `tls:`
+  - `cert_file` (no default): path to the TLS cert to use for TLS required connections. Should
+    only be used if `insecure` is set to false.
+  - `key_file` (no default): path to the TLS key to use for TLS required connections. Should
+    only be used if `insecure` is set to false.
 
 The following settings can be optionally configured:
 

--- a/exporter/zipkinexporter/README.md
+++ b/exporter/zipkinexporter/README.md
@@ -14,15 +14,17 @@ The following settings are required:
 
 By default, TLS is enabled:
 
-- `insecure` (default = `false`): whether to enable client transport security for
-  the exporter's connection.
+- `tls:`
+  - `insecure` (default = `false`): whether to enable client transport security for
+    the exporter's connection.
 
 As a result, the following parameters are also required:
 
-- `cert_file` (no default): path to the TLS cert to use for TLS required connections. Should
-  only be used if `insecure` is set to false.
-- `key_file` (no default): path to the TLS key to use for TLS required connections. Should
-  only be used if `insecure` is set to false.
+- `tls:`
+  - `cert_file` (no default): path to the TLS cert to use for TLS required connections. Should
+    only be used if `insecure` is set to false.
+  - `key_file` (no default): path to the TLS key to use for TLS required connections. Should
+    only be used if `insecure` is set to false.
 
 The following settings are optional:
 
@@ -35,11 +37,13 @@ Example:
 exporters:
   zipkin:
     endpoint: "http://some.url:9411/api/v2/spans"
-    cert_file: file.cert
-    key_file: file.key
+    tls:
+      cert_file: file.cert
+      key_file: file.key
   zipkin/2:
     endpoint: "http://some.url:9411/api/v2/spans"
-    insecure: true
+    tls:
+      insecure: true
 ```
 
 ## Advanced Configuration

--- a/extension/awsxrayproxy/README.md
+++ b/extension/awsxrayproxy/README.md
@@ -17,8 +17,9 @@ extensions:
   awsxrayproxy:
     endpoint: 0.0.0.0:2000
     proxy_address: ""
-    insecure: false
-    server_name_override: ""
+    tls:
+      insecure: false
+      server_name_override: ""
     region: ""
     role_arn: ""
     aws_endpoint: ""

--- a/extension/awsxrayproxy/testdata/config.yaml
+++ b/extension/awsxrayproxy/testdata/config.yaml
@@ -3,8 +3,9 @@ extensions:
   awsxrayproxy/1:
     endpoint: "0.0.0.0:1234"
     proxy_address: "https://proxy.proxy.com"
-    insecure: true
-    server_name_override: "something"
+    tls:
+      insecure: true
+      server_name_override: "something"
     region: "us-west-1"
     role_arn: "arn:aws:iam::123456789012:role/awesome_role"
     aws_endpoint: "https://another.aws.endpoint.com"

--- a/extension/oauth2clientauthextension/README.md
+++ b/extension/oauth2clientauthextension/README.md
@@ -17,10 +17,10 @@ extensions:
     scopes: ["api.metrics"]
     # tls settings for the token client
     tls:
-        insecure: true
-        ca_file: /var/lib/mycert.pem
-        cert_file: certfile
-        key_file: keyfile
+      insecure: true
+      ca_file: /var/lib/mycert.pem
+      cert_file: certfile
+      key_file: keyfile
     # timeout for the token client
     timeout: 2s
     

--- a/receiver/awsxrayreceiver/README.md
+++ b/receiver/awsxrayreceiver/README.md
@@ -18,8 +18,9 @@ receivers:
     proxy_server:
       endpoint: 0.0.0.0:2000
       proxy_address: ""
-      insecure: false
-      server_name_override: ""
+      tls:
+        insecure: false
+        server_name_override: ""
       region: ""
       role_arn: ""
       aws_endpoint: ""

--- a/receiver/awsxrayreceiver/testdata/config.yaml
+++ b/receiver/awsxrayreceiver/testdata/config.yaml
@@ -12,8 +12,9 @@ receivers:
     proxy_server:
       endpoint: "0.0.0.0:1234"
       proxy_address: "https://proxy.proxy.com"
-      insecure: true
-      server_name_override: "something"
+      tls:
+        insecure: true
+        server_name_override: "something"
       region: "us-west-1"
       role_arn: "arn:aws:iam::123456789012:role/awesome_role"
       aws_endpoint: "https://another.aws.endpoint.com"


### PR DESCRIPTION
**Description:**
This PR updates `README`s and `yaml`s to change insecure property under `tls:`

**Before**
```
exporters:
  otlp:
    endpoint: 1.2.3.4:4317
    insecure: true
```

**After**
```
exporters:
  otlp:
    endpoint: 1.2.3.4:4317
    tls:
      insecure: true
```

**Link to tracking Issue:**
Issue 5385