### PR TITLE
Split stability tests into a separate Github Actions workflow 

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -82,9 +82,7 @@ jobs:
       - name: Split Loadtest Jobs
         id: splitloadtest
         run: ./.github/workflows/scripts/setup_e2e_tests.sh
-      - name: Split Stability Jobs
-        id: splitstabilitytest
-        run: ./.github/workflows/scripts/setup_stability_tests.sh
+
   lint:
     runs-on: ubuntu-latest
     needs: [setup-environment]
@@ -262,48 +260,6 @@ jobs:
           key: v1-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
       - name: Correctness
         run: make -C testbed run-correctness-metrics-tests
-
-  stability-tests:
-    # Stability tests disabled in the makefile. We disable them here to avoid
-    # consuming workers just to run a noop make target.
-    # uncomment the following line to enable stability tests.
-    # if: ${{ github.ref == 'ref/head/main' }}
-    if: ${{ false }}
-    runs-on: ubuntu-latest
-    needs: [setup-environment]
-    strategy:
-      matrix: ${{ fromJson(needs.setup-environment.outputs.stabilitytest_matrix) }}
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v2
-      - name: Setup Go
-        uses: actions/setup-go@v2.1.4
-        with:
-          go-version: 1.17
-      - name: Setup Go Environment
-        run: |
-          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-      - name: Cache Go
-        id: module-cache
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-go-modules
-        with:
-          path: |
-            /home/runner/go/pkg/mod
-            /home/runner/.cache/go-build
-          key: v1-go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum') }}
-      - name: Run Stability Tests
-        run: |
-          echo "Running ${matrix.test}..."
-          TEST_ARGS="-test.run=${matrix.test}" make stability-tests
-      - name: Upload Unit Test Results
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: unittests-results
-          path: test-results/junit/results.xml
 
   build-examples:
     runs-on: ubuntu-latest

--- a/.github/workflows/stability-tests.yml
+++ b/.github/workflows/stability-tests.yml
@@ -1,0 +1,99 @@
+name: stability-tests
+on:
+  push:
+    branches: [ main ]
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+  pull_request:
+
+jobs:
+  setup-environment:
+    runs-on: ubuntu-latest
+    outputs:
+      stabilitytest_matrix: ${{ steps.splitstabilitytest.outputs.stabilitytest_matrix}}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v2.1.4
+        with:
+          go-version: 1.17
+      - name: Setup Go Environment
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+      - name: Cache Go
+        id: module-cache
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-go-modules
+        with:
+          path: |
+            /home/runner/go/pkg/mod
+            /home/runner/.cache/go-build
+          key: v1-go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum') }}
+      - name: Cache Tools
+        id: tool-cache
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-tool-binaries
+        with:
+          path: /home/runner/go/bin
+          key: v1-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
+      - name: Install dependencies
+        if: steps.module-cache.outputs.hit != 'true'
+        run: make gomoddownload
+      - name: Install Tools
+        if: steps.tool-cache.outputs.cache-hit != 'true'
+        run: make install-tools
+      - name: Split Stability Jobs
+        id: splitstabilitytest
+        run: ./.github/workflows/scripts/setup_stability_tests.sh
+
+  stability-tests:
+    # Stability tests disabled in the makefile. We disable them here to avoid
+    # consuming workers just to run a noop make target.
+    # uncomment the following line to enable stability tests.
+    # if: ${{ github.ref == 'ref/head/main' }}
+    # if: ${{ false }}
+    runs-on: ubuntu-latest
+    needs: [setup-environment]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup-environment.outputs.stabilitytest_matrix) }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v2.1.4
+        with:
+          go-version: 1.17
+      - name: Setup Go Environment
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+      - name: Cache Go
+        id: module-cache
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-go-modules
+        with:
+          path: |
+            /home/runner/go/pkg/mod
+            /home/runner/.cache/go-build
+          key: v1-go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum') }}
+      - name: Run Stability Tests
+        run: make stability-tests
+        env:
+          TEST_ARGS: "-test.run=${{ matrix.test }}"
+      - name: Create Test Result Archive
+        if: ${{ failure() || success() }}
+        continue-on-error: true
+        run: tar -cvf stabilitytest_results.tar testbed/stabilitytests/results
+      - name: Upload Test Results
+        if: ${{ failure() || success() }}
+        continue-on-error: true
+        uses: actions/upload-artifact@v2
+        with:
+          name: stability-test-results
+          path: stabilitytest_results.tar


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Added a separate workflow for Stability tests, making it easier to enable or disable
Note: this new workflow runs `make stability-tests`, and the makefile currently has the the stability-tests as disabled:
```
.PHONY: stability-tests
stability-tests: otelcontribcol
	@echo Stability tests are disabled until we have a stable performance environment.
	@echo To enable the tests replace this echo by $(MAKE) -C testbed run-stability-tests
```
As a result, the new workflow will run a noop make target until the tests are enabled (This new workflow can be disabled until then)
**Link to tracking Issue:** <Issue number if applicable>
Issue 4045