### PR TITLE
make flaky test TestStartTimeMetricRegex more reliable

### DIFF
--- a/receiver/prometheusreceiver/metrics_receiver_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_test.go
@@ -1364,18 +1364,19 @@ var startTimeMetricPageStartTimestamp = &timestamppb.Timestamp{Seconds: 400, Nan
 const numStartTimeMetricPageTimeseries = 11
 
 func verifyStartTimeMetricPage(t *testing.T, _ *testData, mds []*agentmetricspb.ExportMetricsServiceRequest) {
+	if len(mds) < 1 {
+		t.Fatal("At least one metric request should be present")
+	}
 	numTimeseries := 0
-	for _, cmd := range mds {
-		for _, metric := range cmd.Metrics {
-			timestamp := startTimeMetricPageStartTimestamp
-			switch metric.GetMetricDescriptor().GetType() {
-			case metricspb.MetricDescriptor_GAUGE_DOUBLE, metricspb.MetricDescriptor_GAUGE_DISTRIBUTION:
-				timestamp = nil
-			}
-			for _, ts := range metric.GetTimeseries() {
-				assert.Equal(t, timestamp.AsTime(), ts.GetStartTimestamp().AsTime(), ts.String())
-				numTimeseries++
-			}
+	for _, metric := range mds[0].Metrics {
+		timestamp := startTimeMetricPageStartTimestamp
+		switch metric.GetMetricDescriptor().GetType() {
+		case metricspb.MetricDescriptor_GAUGE_DOUBLE, metricspb.MetricDescriptor_GAUGE_DISTRIBUTION:
+			timestamp = nil
+		}
+		for _, ts := range metric.GetTimeseries() {
+			assert.Equal(t, timestamp.AsTime(), ts.GetStartTimestamp().AsTime(), ts.String())
+			numTimeseries++
 		}
 	}
 	assert.Equal(t, numStartTimeMetricPageTimeseries, numTimeseries)
@@ -1521,7 +1522,7 @@ func TestStartTimeMetricRegex(t *testing.T) {
 func testEndToEndRegex(t *testing.T, targets []*testData, useStartTimeMetric bool, startTimeMetricRegex string) {
 	// 1. setup mock server
 	mp, cfg, err := setupMockPrometheus(targets...)
-	require.Nilf(t, err, "Failed to create Promtheus config: %v", err)
+	require.Nilf(t, err, "Failed to create Prometheus config: %v", err)
 	defer mp.Close()
 
 	cms := new(consumertest.MetricsSink)

--- a/receiver/prometheusreceiver/metrics_receiver_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_test.go
@@ -1364,9 +1364,7 @@ var startTimeMetricPageStartTimestamp = &timestamppb.Timestamp{Seconds: 400, Nan
 const numStartTimeMetricPageTimeseries = 11
 
 func verifyStartTimeMetricPage(t *testing.T, _ *testData, mds []*agentmetricspb.ExportMetricsServiceRequest) {
-	if len(mds) < 1 {
-		t.Fatal("At least one metric request should be present")
-	}
+	require.Greater(t, len(mds), 0, "At least one metric request should be present")
 	numTimeseries := 0
 	for _, metric := range mds[0].Metrics {
 		timestamp := startTimeMetricPageStartTimestamp


### PR DESCRIPTION
**Description:** <Describe what has changed.>
`TestStartTimeMetricRegex` is flaky as it failed in a unit test workflow run according to issue #5752 
Unable to reproduce this failure locally by running this test multiple times.
However, based on the error trace in the issue description, the test is flaky as it intermittently generates an additional scrape result with staleness markers. 
In order to make this test more reliable, we should only validate the first scrape result and ignore any subsequent scrapes.

_Error trace from issue 5752:_ 
```
make[2]: Entering directory '/home/runner/work/opentelemetry-collector-contrib/opentelemetry-collector-contrib/receiver/prometheusreceiver'
go test -race -timeout 300s --tags="" ./...
--- FAIL: TestStartTimeMetricRegex (12.72s)
    metrics_receiver_test.go:1379: 
        	Error Trace:	metrics_receiver_test.go:1379
        	            				metrics_receiver_test.go:1564
        	            				metrics_receiver_test.go:1520
        	Error:      	Not equal: 
        	            	expected: time.Date(1970, time.January, 1, 0, 6, 40, 800000000, time.UTC)
        	            	actual  : time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,4 +1,4 @@
        	            	 (time.Time) {
        	            	- wall: (uint64) 800000000,
        	            	- ext: (int64) 62135597200,
        	            	+ wall: (uint64) 0,
        	            	+ ext: (int64) 62135596800,
        	            	  loc: (*time.Location)(<nil>)
        	Test:       	TestStartTimeMetricRegex
        	Messages:   	label_values:{value:"400" has_value:true} label_values:{value:"post" has_value:true} points:{timestamp:{seconds:1634220661 nanos:999000000} double_value:nan}
    metrics_receiver_test.go:1379: 
        	Error Trace:	metrics_receiver_test.go:1379
        	            				metrics_receiver_test.go:1564
        	            				metrics_receiver_test.go:1520
        	Error:      	Not equal: 
        	            	expected: time.Date(1970, time.January, 1, 0, 6, 40, 800000000, time.UTC)
        	            	actual  : time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,4 +1,4 @@
        	            	 (time.Time) {
        	            	- wall: (uint64) 800000000,
        	            	- ext: (int64) 62135597200,
        	            	+ wall: (uint64) 0,
        	            	+ ext: (int64) 62135596800,
        	            	  loc: (*time.Location)(<nil>)
        	Test:       	TestStartTimeMetricRegex
        	Messages:   	label_values:{value:"200" has_value:true} label_values:{value:"post" has_value:true} points:{timestamp:{seconds:1634220661 nanos:999000000} double_value:nan}
    metrics_receiver_test.go:1379: 
        	Error Trace:	metrics_receiver_test.go:1379
        	            				metrics_receiver_test.go:1564
        	            				metrics_receiver_test.go:1520
        	Error:      	Not equal: 
        	            	expected: time.Date(1970, time.January, 1, 0, 6, 40, 800000000, time.UTC)
        	            	actual  : time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,4 +1,4 @@
        	            	 (time.Time) {
        	            	- wall: (uint64) 800000000,
        	            	- ext: (int64) 62135597200,
        	            	+ wall: (uint64) 0,
        	            	+ ext: (int64) 62135596800,
        	            	  loc: (*time.Location)(<nil>)
        	Test:       	TestStartTimeMetricRegex
        	Messages:   	points:{timestamp:{seconds:1634220661 nanos:999000000} distribution_value:{count:-9223372036854775808 buckets:{count:-9223372036854775808}}}
    metrics_receiver_test.go:1379: 
        	Error Trace:	metrics_receiver_test.go:1379
        	            				metrics_receiver_test.go:1564
        	            				metrics_receiver_test.go:1520
        	Error:      	Not equal: 
        	            	expected: time.Date(1970, time.January, 1, 0, 6, 40, 800000000, time.UTC)
        	            	actual  : time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,4 +1,4 @@
        	            	 (time.Time) {
        	            	- wall: (uint64) 800000000,
        	            	- ext: (int64) 62135597200,
        	            	+ wall: (uint64) 0,
        	            	+ ext: (int64) 62135596800,
        	            	  loc: (*time.Location)(<nil>)
        	Test:       	TestStartTimeMetricRegex
        	Messages:   	points:{timestamp:{seconds:1634220661 nanos:999000000} summary_value:{count:{value:-9223372036854775808} sum:{} snapshot:{percentile_values:{percentile:1 value:nan}}}}
    metrics_receiver_test.go:1384: 
        	Error Trace:	metrics_receiver_test.go:1384
        	            				metrics_receiver_test.go:1564
        	            				metrics_receiver_test.go:1520
        	Error:      	Not equal: 
        	            	expected: 11
        	            	actual  : 22
        	Test:       	TestStartTimeMetricRegex
FAIL
FAIL	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver	38.324s

```
**Link to tracking Issue:** <Issue number if applicable>
Issue 5752 