### PR TITLE
Validate Prometheus Remote Write Exporter MUST NOT retry write requests on HTTP 2xx and 4xx responses other than 429

### DIFF
--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -232,7 +232,7 @@ func Test_Shutdown(t *testing.T) {
 
 type serverTestSet struct {
 	testName            string
-	ts                  prompb.TimeSeries
+	ts                  *prompb.TimeSeries
 	serverUp            bool
 	httpResponseCodes   []int
 	returnErrorOnCreate bool
@@ -284,7 +284,7 @@ func Test_export(t *testing.T) {
 	// are properly identified
 	tests := []serverTestSet{
 		{"success_case",
-			*ts1,
+			ts1,
 			true,
 			[]int{http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNonAuthoritativeInfo, http.StatusNoContent, http.StatusResetContent,
 				http.StatusPartialContent, http.StatusMultiStatus, http.StatusAlreadyReported, http.StatusIMUsed},
@@ -292,13 +292,13 @@ func Test_export(t *testing.T) {
 		},
 		{
 			"server_no_response_case",
-			*ts1,
+			ts1,
 			false,
 			[]int{http.StatusAccepted},
 			true,
 		}, {
 			"error_status_code_case",
-			*ts1,
+			ts1,
 			true,
 			[]int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusPaymentRequired, http.StatusForbidden, http.StatusNotFound,
 				http.StatusMethodNotAllowed, http.StatusNotAcceptable, http.StatusProxyAuthRequired, http.StatusRequestTimeout, http.StatusConflict, http.StatusGone,


### PR DESCRIPTION
**Description:** 
This PR is to validate Prometheus Remote Write compatible senders MUST NOT retry write requests on HTTP 2xx and 4xx responses other than 429 as per Prometheus Remote-Write Specification v0.1.

Todo: check and discuss to file an issue upstream