### PR TITLE
[Prometheus Exporter] Fix Issue 6228: Flaky End to End Test

### DIFF
--- a/exporter/prometheusexporter/end_to_end_test.go
+++ b/exporter/prometheusexporter/end_to_end_test.go
@@ -83,7 +83,7 @@ func TestEndToEndSummarySupport(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err = exporter.Start(ctx, nil); err != nil {
-		t.Fatalf("Failed to start the Prometheus receiver: %v", err)
+		t.Fatalf("Failed to start the Prometheus exporter: %v", err)
 	}
 	t.Cleanup(func() { require.NoError(t, exporter.Shutdown(ctx)) })
 
@@ -110,7 +110,7 @@ func TestEndToEndSummarySupport(t *testing.T) {
 		PrometheusConfig: receiverConfig,
 		ReceiverSettings: config.NewReceiverSettings(config.NewComponentID("prometheus")),
 	}
-	// 3.5 Create the Prometheus receiver and pass in the preivously created Prometheus exporter.
+	// 3.5 Create the Prometheus receiver and pass in the previously created Prometheus exporter.
 	prometheusReceiver, err := receiverFactory.CreateMetricsReceiver(ctx, receiverCreateSet, rcvCfg, exporter)
 	if err != nil {
 		t.Fatal(err)
@@ -121,7 +121,7 @@ func TestEndToEndSummarySupport(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, prometheusReceiver.Shutdown(ctx)) })
 
 	// 4. Scrape from the Prometheus exporter to ensure that we export summary metrics
-	// We shall let the Prometheus exporter scrape the DropWizard mock server, at least 9 times.
+	// We shall let the Prometheus exporter scrape the DropWizard mock server, at least 8 times.
 	for i := 0; i < 8; i++ {
 		<-waitForScrape
 	}

--- a/exporter/prometheusexporter/end_to_end_test.go
+++ b/exporter/prometheusexporter/end_to_end_test.go
@@ -51,6 +51,10 @@ func TestEndToEndSummarySupport(t *testing.T) {
 			// Serve back the metrics as if they were from DropWizard.
 			_, err := rw.Write([]byte(dropWizardResponse))
 			require.NoError(t, err)
+		default:
+			// Non-blocking serve for DropWizard
+			_, err := rw.Write([]byte(dropWizardResponse))
+			require.NoError(t, err)
 		}
 	}))
 	defer dropWizardServer.Close()


### PR DESCRIPTION
**Description:** 

Current design has buffer capacity of 1 for `waitForScrapes` channel, and may not be enough for `scrape_interval` of 2ms. 
After ensuring that receiver has scraped target from test server 8 times; and before the GET request is made to fetch metrics from the exposed Prometheus exporter end points -- the Prometheus Receiver keeps trying to scrape metrics and when it does not get any response (as response is blocked because channel has only 1 buffer capacity against 2ms `scrape_interval`) Prometheus Receiver generate failed scrapes (`staleNaN` and so on)  - and that's why this test is flaky.  
So solution is to avoid generation of failed scrapes by ensuring that there is always a response to Prometheus Receiver GET requests from test server. 
- Added non-blocking serve for `dropWizard`.



**Link to tracking Issue:** 
Issue 6228

cc @alolita @Aneurysm9 