### PR TITLE
Ensure Prometheus Remote Write Exporter respond to OTLP data format from Prometheus Receiver

### DIFF
--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
+	"github.com/prometheus/prometheus/pkg/value"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -380,7 +381,16 @@ func Test_PushMetrics(t *testing.T) {
 
 	emptySummaryBatch := getMetricsFromMetricList(invalidMetrics[emptySummary])
 
-	checkFunc := func(t *testing.T, r *http.Request, expected int) {
+	// staleNaN cases
+	staleNaNIntGaugeBatch := getMetricsFromMetricList(staleNaNMetrics[staleNaNIntGauge])
+
+	staleNaNDoubleGaugeBatch := getMetricsFromMetricList(staleNaNMetrics[staleNaNDoubleGauge])
+
+	staleNaNIntSumBatch := getMetricsFromMetricList(staleNaNMetrics[staleNaNIntSum])
+
+	staleNaNSumBatch := getMetricsFromMetricList(staleNaNMetrics[staleNaNSum])
+
+	checkFunc := func(t *testing.T, r *http.Request, expected int, isStaleMarker bool) {
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			t.Fatal(err)
@@ -397,15 +407,19 @@ func Test_PushMetrics(t *testing.T) {
 		ok := proto.Unmarshal(dest, wr)
 		require.Nil(t, ok)
 		assert.EqualValues(t, expected, len(wr.Timeseries))
+		if isStaleMarker {
+			assert.True(t, value.IsStaleNaN(wr.Timeseries[0].Samples[0].Value))
+		}
 	}
 
 	tests := []struct {
 		name               string
 		md                 *pdata.Metrics
-		reqTestFunc        func(t *testing.T, r *http.Request, expected int)
+		reqTestFunc        func(t *testing.T, r *http.Request, expected int, isStaleMarker bool)
 		expectedTimeSeries int
 		httpResponseCode   int
 		returnErr          bool
+		isStaleMarker      bool
 	}{
 		{
 			"invalid_type_case",
@@ -414,6 +428,7 @@ func Test_PushMetrics(t *testing.T) {
 			0,
 			http.StatusAccepted,
 			true,
+			false,
 		},
 		{
 			"intSum_case",
@@ -421,6 +436,7 @@ func Test_PushMetrics(t *testing.T) {
 			checkFunc,
 			2,
 			http.StatusAccepted,
+			false,
 			false,
 		},
 		{
@@ -430,6 +446,7 @@ func Test_PushMetrics(t *testing.T) {
 			2,
 			http.StatusAccepted,
 			false,
+			false,
 		},
 		{
 			"doubleGauge_case",
@@ -437,6 +454,7 @@ func Test_PushMetrics(t *testing.T) {
 			checkFunc,
 			2,
 			http.StatusAccepted,
+			false,
 			false,
 		},
 		{
@@ -446,6 +464,7 @@ func Test_PushMetrics(t *testing.T) {
 			2,
 			http.StatusAccepted,
 			false,
+			false,
 		},
 		{
 			"histogram_case",
@@ -453,6 +472,7 @@ func Test_PushMetrics(t *testing.T) {
 			checkFunc,
 			12,
 			http.StatusAccepted,
+			false,
 			false,
 		},
 		{
@@ -462,6 +482,7 @@ func Test_PushMetrics(t *testing.T) {
 			10,
 			http.StatusAccepted,
 			false,
+			false,
 		},
 		{
 			"unmatchedBoundBucketHist_case",
@@ -469,6 +490,7 @@ func Test_PushMetrics(t *testing.T) {
 			checkFunc,
 			5,
 			http.StatusAccepted,
+			false,
 			false,
 		},
 		{
@@ -478,6 +500,7 @@ func Test_PushMetrics(t *testing.T) {
 			5,
 			http.StatusServiceUnavailable,
 			true,
+			false,
 		},
 		{
 			"emptyGauge_case",
@@ -486,6 +509,7 @@ func Test_PushMetrics(t *testing.T) {
 			0,
 			http.StatusAccepted,
 			true,
+			false,
 		},
 		{
 			"emptyCumulativeSum_case",
@@ -494,6 +518,7 @@ func Test_PushMetrics(t *testing.T) {
 			0,
 			http.StatusAccepted,
 			true,
+			false,
 		},
 		{
 			"emptyCumulativeHistogram_case",
@@ -502,6 +527,7 @@ func Test_PushMetrics(t *testing.T) {
 			0,
 			http.StatusAccepted,
 			true,
+			false,
 		},
 		{
 			"emptySummary_case",
@@ -510,6 +536,43 @@ func Test_PushMetrics(t *testing.T) {
 			0,
 			http.StatusAccepted,
 			true,
+			false,
+		},
+		{
+			"staleNaNIntGauge_case",
+			&staleNaNIntGaugeBatch,
+			checkFunc,
+			1,
+			http.StatusAccepted,
+			false,
+			true,
+		},
+		{
+			"staleNaNDoubleGauge_case",
+			&staleNaNDoubleGaugeBatch,
+			checkFunc,
+			1,
+			http.StatusAccepted,
+			false,
+			true,
+		},
+		{
+			"staleNaNIntSum_case",
+			&staleNaNIntSumBatch,
+			checkFunc,
+			1,
+			http.StatusAccepted,
+			false,
+			true,
+		},
+		{
+			"staleNaNSum_case",
+			&staleNaNSumBatch,
+			checkFunc,
+			1,
+			http.StatusAccepted,
+			false,
+			true,
 		},
 	}
 
@@ -517,7 +580,7 @@ func Test_PushMetrics(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if tt.reqTestFunc != nil {
-					tt.reqTestFunc(t, r, tt.expectedTimeSeries)
+					tt.reqTestFunc(t, r, tt.expectedTimeSeries, tt.isStaleMarker)
 				}
 				w.WriteHeader(tt.httpResponseCode)
 			}))

--- a/exporter/prometheusremotewriteexporter/testutil_test.go
+++ b/exporter/prometheusremotewriteexporter/testutil_test.go
@@ -17,9 +17,9 @@ package prometheusremotewriteexporter
 import (
 	"fmt"
 	"math"
+	"strings"
 	"time"
 
-	"github.com/prometheus/prometheus/pkg/value"
 	"github.com/prometheus/prometheus/prompb"
 	"go.opentelemetry.io/collector/model/pdata"
 )
@@ -51,14 +51,11 @@ var (
 	traceIDValue1 = "traceID-value1"
 	traceIDKey    = "trace_id"
 
-	intVal1 int64 = 1
-	intVal2 int64 = 2
-	intVal3       = int64(value.StaleNaN)
-
-	floatVal1 = 1.0
-	floatVal2 = 2.0
-	floatVal3 = 3.0
-	floatVal4 = math.Float64frombits(value.StaleNaN)
+	intVal1   int64 = 1
+	intVal2   int64 = 2
+	floatVal1       = 1.0
+	floatVal2       = 2.0
+	floatVal3       = 3.0
 
 	lbs1      = getAttributes(label11, value11, label12, value12)
 	lbs2      = getAttributes(label21, value21, label22, value22)
@@ -169,10 +166,10 @@ var (
 
 	// staleNaN metrics as input should have the staleness marker flag
 	staleNaNMetrics = map[string]pdata.Metric{
-		staleNaNIntGauge:    getIntGaugeMetric(staleNaNIntGauge, lbs1, intVal3, time1),
-		staleNaNDoubleGauge: getDoubleGaugeMetric(staleNaNDoubleGauge, lbs1, floatVal4, time1),
-		staleNaNIntSum:      getIntSumMetric(staleNaNIntSum, lbs1, intVal3, time1),
-		staleNaNSum:         getSumMetric(staleNaNSum, lbs1, floatVal4, time1),
+		staleNaNIntGauge:    getIntGaugeMetric(staleNaNIntGauge, lbs1, intVal1, time1),
+		staleNaNDoubleGauge: getDoubleGaugeMetric(staleNaNDoubleGauge, lbs1, floatVal1, time1),
+		staleNaNIntSum:      getIntSumMetric(staleNaNIntSum, lbs1, intVal1, time1),
+		staleNaNSum:         getSumMetric(staleNaNSum, lbs1, floatVal1, time1),
 	}
 )
 
@@ -289,15 +286,15 @@ func getEmptyGaugeMetric(name string) pdata.Metric {
 	return metric
 }
 
-func getIntGaugeMetric(name string, attributes pdata.AttributeMap, val int64, ts uint64) pdata.Metric {
+func getIntGaugeMetric(name string, attributes pdata.AttributeMap, value int64, ts uint64) pdata.Metric {
 	metric := pdata.NewMetric()
 	metric.SetName(name)
 	metric.SetDataType(pdata.MetricDataTypeGauge)
 	dp := metric.Gauge().DataPoints().AppendEmpty()
-	if value.IsStaleNaN(math.Float64frombits(uint64(val))) {
+	if strings.HasPrefix(name, "staleNaN") {
 		dp.SetFlags(1)
 	}
-	dp.SetIntVal(val)
+	dp.SetIntVal(value)
 	attributes.CopyTo(dp.Attributes())
 
 	dp.SetStartTimestamp(pdata.Timestamp(0))
@@ -305,15 +302,15 @@ func getIntGaugeMetric(name string, attributes pdata.AttributeMap, val int64, ts
 	return metric
 }
 
-func getDoubleGaugeMetric(name string, attributes pdata.AttributeMap, val float64, ts uint64) pdata.Metric {
+func getDoubleGaugeMetric(name string, attributes pdata.AttributeMap, value float64, ts uint64) pdata.Metric {
 	metric := pdata.NewMetric()
 	metric.SetName(name)
 	metric.SetDataType(pdata.MetricDataTypeGauge)
 	dp := metric.Gauge().DataPoints().AppendEmpty()
-	if value.IsStaleNaN(val) {
+	if strings.HasPrefix(name, "staleNaN") {
 		dp.SetFlags(1)
 	}
-	dp.SetDoubleVal(val)
+	dp.SetDoubleVal(value)
 	attributes.CopyTo(dp.Attributes())
 
 	dp.SetStartTimestamp(pdata.Timestamp(0))
@@ -328,16 +325,16 @@ func getEmptySumMetric(name string) pdata.Metric {
 	return metric
 }
 
-func getIntSumMetric(name string, attributes pdata.AttributeMap, val int64, ts uint64) pdata.Metric {
+func getIntSumMetric(name string, attributes pdata.AttributeMap, value int64, ts uint64) pdata.Metric {
 	metric := pdata.NewMetric()
 	metric.SetName(name)
 	metric.SetDataType(pdata.MetricDataTypeSum)
 	metric.Sum().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
 	dp := metric.Sum().DataPoints().AppendEmpty()
-	if value.IsStaleNaN(math.Float64frombits(uint64(val))) {
+	if strings.HasPrefix(name, "staleNaN") {
 		dp.SetFlags(1)
 	}
-	dp.SetIntVal(val)
+	dp.SetIntVal(value)
 	attributes.CopyTo(dp.Attributes())
 
 	dp.SetStartTimestamp(pdata.Timestamp(0))
@@ -353,16 +350,16 @@ func getEmptyCumulativeSumMetric(name string) pdata.Metric {
 	return metric
 }
 
-func getSumMetric(name string, attributes pdata.AttributeMap, val float64, ts uint64) pdata.Metric {
+func getSumMetric(name string, attributes pdata.AttributeMap, value float64, ts uint64) pdata.Metric {
 	metric := pdata.NewMetric()
 	metric.SetName(name)
 	metric.SetDataType(pdata.MetricDataTypeSum)
 	metric.Sum().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
 	dp := metric.Sum().DataPoints().AppendEmpty()
-	if value.IsStaleNaN(val) {
+	if strings.HasPrefix(name, "staleNaN") {
 		dp.SetFlags(1)
 	}
-	dp.SetDoubleVal(val)
+	dp.SetDoubleVal(value)
 	attributes.CopyTo(dp.Attributes())
 
 	dp.SetStartTimestamp(pdata.Timestamp(0))


### PR DESCRIPTION
**Description:** 
This PR is to ensure the Prometheus Remote Write Exporter responds to OTLP data format from the Prometheus Receiver, specifically for the metric data types of gauge and sum, to check and handle the OTLP [MetricDataPointFlagNoRecordedValue](https://github.com/open-telemetry/opentelemetry-collector/blob/0b4e5ec7924c56342c0ab453ca3dc99bbe3642cd/model/pdata/metrics.go#L285) flag for staleness and set the sample value of the data point containing this flag to the `StaleNaN` value. 
**Link to tracking Issue:** 
Issue # 6620 
**Testing:**
Test cases have been implemented to verify the sample value of a datapoint with the OTLP flag for staleness is set to the `staleNaN` value for the metric data types, gauge and sum. 