### PR TITLE
[Prometheus Exporter] Handling Staleness flag from OTLP.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 💡 Enhancements 💡
 
 - `prometheusremotewriteexporter`: Handling Staleness flag from OTLP (#6679)
+- `prometheusexporter`: Handling Staleness flag from OTLP (#6805)
 
 ## 🛑 Breaking changes 🛑
 

--- a/exporter/prometheusexporter/accumulator.go
+++ b/exporter/prometheusexporter/accumulator.go
@@ -105,6 +105,10 @@ func (a *lastValueAccumulator) accumulateSummary(metric pdata.Metric, il pdata.I
 		ip := dps.At(i)
 
 		signature := timeseriesSignature(il.Name(), metric, ip.Attributes())
+		if ip.Flags().HasFlag(pdata.MetricDataPointFlagNoRecordedValue) {
+			a.registeredMetrics.Delete(signature)
+			return 0
+		}
 
 		v, ok := a.registeredMetrics.Load(signature)
 		stalePoint := ok &&
@@ -130,6 +134,10 @@ func (a *lastValueAccumulator) accumulateGauge(metric pdata.Metric, il pdata.Ins
 		ip := dps.At(i)
 
 		signature := timeseriesSignature(il.Name(), metric, ip.Attributes())
+		if ip.Flags().HasFlag(pdata.MetricDataPointFlagNoRecordedValue) {
+			a.registeredMetrics.Delete(signature)
+			return 0
+		}
 
 		v, ok := a.registeredMetrics.Load(signature)
 		if !ok {
@@ -167,6 +175,10 @@ func (a *lastValueAccumulator) accumulateSum(metric pdata.Metric, il pdata.Instr
 		ip := dps.At(i)
 
 		signature := timeseriesSignature(il.Name(), metric, ip.Attributes())
+		if ip.Flags().HasFlag(pdata.MetricDataPointFlagNoRecordedValue) {
+			a.registeredMetrics.Delete(signature)
+			return 0
+		}
 
 		v, ok := a.registeredMetrics.Load(signature)
 		if !ok {
@@ -208,6 +220,10 @@ func (a *lastValueAccumulator) accumulateDoubleHistogram(metric pdata.Metric, il
 		ip := dps.At(i)
 
 		signature := timeseriesSignature(il.Name(), metric, ip.Attributes())
+		if ip.Flags().HasFlag(pdata.MetricDataPointFlagNoRecordedValue) {
+			a.registeredMetrics.Delete(signature)
+			return 0
+		}
 
 		v, ok := a.registeredMetrics.Load(signature)
 		if !ok {

--- a/exporter/prometheusexporter/accumulator_test.go
+++ b/exporter/prometheusexporter/accumulator_test.go
@@ -251,7 +251,7 @@ func TestAccumulateMetrics(t *testing.T) {
 				dp.Attributes().InsertString("label_1", "1")
 				dp.Attributes().InsertString("label_2", "2")
 				dp.SetTimestamp(pdata.NewTimestampFromTime(ts))
-				dp.SetFlags(1)
+				dp.SetFlags(pdata.MetricDataPointFlags(pdata.MetricDataPointFlagNoRecordedValue))
 			},
 		},
 		{
@@ -268,7 +268,7 @@ func TestAccumulateMetrics(t *testing.T) {
 				dp.Attributes().InsertString("label_1", "1")
 				dp.Attributes().InsertString("label_2", "2")
 				dp.SetTimestamp(pdata.NewTimestampFromTime(ts))
-				dp.SetFlags(1)
+				dp.SetFlags(pdata.MetricDataPointFlags(pdata.MetricDataPointFlagNoRecordedValue))
 			},
 		},
 		{
@@ -287,7 +287,7 @@ func TestAccumulateMetrics(t *testing.T) {
 				dp.Attributes().InsertString("label_1", "1")
 				dp.Attributes().InsertString("label_2", "2")
 				dp.SetTimestamp(pdata.NewTimestampFromTime(ts))
-				dp.SetFlags(1)
+				dp.SetFlags(pdata.MetricDataPointFlags(pdata.MetricDataPointFlagNoRecordedValue))
 			},
 		},
 		{
@@ -304,7 +304,7 @@ func TestAccumulateMetrics(t *testing.T) {
 				dp.Attributes().InsertString("label_1", "1")
 				dp.Attributes().InsertString("label_2", "2")
 				dp.SetTimestamp(pdata.NewTimestampFromTime(ts))
-				dp.SetFlags(1)
+				dp.SetFlags(pdata.MetricDataPointFlags(pdata.MetricDataPointFlagNoRecordedValue))
 				fillQuantileValue := func(pN, value float64, dest pdata.ValueAtQuantile) {
 					dest.SetQuantile(pN)
 					dest.SetValue(value)
@@ -335,9 +335,8 @@ func TestAccumulateMetrics(t *testing.T) {
 			if strings.HasPrefix(tt.name, "StalenessMarker") {
 				require.Equal(t, 0, n)
 				return
-			} else {
-				require.Equal(t, 1, n)
 			}
+			require.Equal(t, 1, n)
 
 			m2Labels, _, m2Value, m2Temporality, m2IsMonotonic := getMetricProperties(ilm2.Metrics().At(0))
 


### PR DESCRIPTION
**Description:**
This PR is to ensure the Prometheus Exporter responds to OTLP flags from the Prometheus Receiver for all metric data types, including `gauge`, `sum`, `histogram`, and `summary`.
This PR checks `MetricDataPointFlagNoRecordedValue` flag and drop the metric if flag is enabled.

**Link to tracking Issue:**
issue 6805

**Testing:**
Test cases have been implemented.